### PR TITLE
Remove redundant code

### DIFF
--- a/pymetawear/modules/sensorfusion.py
+++ b/pymetawear/modules/sensorfusion.py
@@ -59,8 +59,6 @@ class SensorFusionModule(PyMetaWearModule):
         else:
             self.available = True
 
-        self.board = board
-
         self.current_active_signal = None
 
         self._streams_to_enable = {


### PR DESCRIPTION
Setting self.board = board is already done in the constructor of the superclass.